### PR TITLE
Bug fix and extensions to libby downloader

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.har
+
+download/*
+libby_env/*

--- a/README.md
+++ b/README.md
@@ -27,19 +27,30 @@ This process will download the MP3 files, and split them into chapters using ffm
 
 1. Execute the script with the necessary arguments
    ```bash
-   python main.py --har_file <NAME OF THE HAR FILE> --name "<NAME TO USE FOR FILE DOWNLOAD" --title "<TITLE OF THE AUDIOBOOK>" --author "<AUTHOR OF THE AUDIOBOOK>" --composer "<NARRATOR OF THE AUDIOBOOK>"
+   python main.py --har_file <NAME OF THE HAR FILE> --name "<ROOT NAME FOR DOWNLOAD FILES>" --title "<AUDIOBOOK TITLE>" \
+   --author "<AUDIOBOOK AUTHOR>" --narrator "<AUDIOBOOK NARRATOR>"
    ```
 
 ### Additional parameters
 
-- has_introduction -> The MP3 files will contain an 'Introduction' chapter
+- --has_introduction -> The MP3 files will contain an 'Introduction' chapter
   - This chapter will occur before the prologue
-- has_prologue -> The MP3 files will contain an 'Prologue' chapter
+- --has_prologue -> The MP3 files will contain an 'Prologue' chapter
   - This chapter will occur after the introduction
-- has_epilogue -> The MP3 files will contain an 'Epilogue' chapter
+- --has_epilogue -> The MP3 files will contain an 'Epilogue' chapter
   - This chapter will occur just before the conclusion
-- has_conclusion -> The MP3 files will contain an 'Conclusion' chapter
+- --has_conclusion -> The MP3 files will contain an 'Conclusion' chapter
   - This chapter will occur after the epilogue
+- --log_level {INFO,DEBUG,WARNING}
+  - Level to use for Logging. Default level is WARNING, which is the least verbose
+- -sdt SILENCE_DURATION_THRESHOLD, --silence_duration_threshold SILENCE_DURATION_THRESHOLD
+  - The length of the silence to use for chapter detection
+- -sdbt SILENCE_DB_THRESHOLD, --silence_db_threshold SILENCE_DB_THRESHOLD
+   -The sound level expressed in dB to use for silence detection
+- -ms MAXIMUM_SILENCE, --maximum_silence MAXIMUM_SILENCE
+   - The length, in seconds, that a silence should be considered. This is helpful to remove trailing silences from an audio file.
+- --no_chapters,
+   - Specify whether to generate chapters from the audiobook. When provided the original Libby parts (~1 hour each) will be output
 
 ### Troubleshooting
 

--- a/main.py
+++ b/main.py
@@ -56,7 +56,7 @@ class AudioBooker:
         parser.add_argument("--name", type=str, help="The name of the book", required=True)
         parser.add_argument("--title", type=str, help="The title of the book", required=True)
         parser.add_argument("--author", type=str, help="The author of the book", required=True)
-        parser.add_argument("--composer", type=str, help="The narrator of the book", required=True)
+        parser.add_argument("--narrator", type=str, help="The narrator of the book", required=True)
         parser.add_argument(
             "-hf", "--har_file", type=str, help="The path to the generated HAR file", default="libbyapp.com.har"
         )

--- a/main.py
+++ b/main.py
@@ -288,7 +288,7 @@ class AudioBooker:
         loaded_har_file = self._load_har_file()
         located_media_links = self._identify_download_urls(loaded_har_file=loaded_har_file)
         downloaded_files = self._download_audiobook_files(located_media_links=located_media_links)
-       for downloaded_file in downloaded_files:
+        for downloaded_file in downloaded_files:
             if self._args.no_chapters:
                 silence_timestamps = []
             else:

--- a/main.py
+++ b/main.py
@@ -88,7 +88,7 @@ class AudioBooker:
             "--log_level",
             type=str,
             help="Level to use for Logging",
-            default="INFO",
+            default="WARNING",
             choices=["INFO", "DEBUG", "WARNING"],
         )
         parser.add_argument(
@@ -124,8 +124,8 @@ class AudioBooker:
 
     def _build_metadata(self) -> str:
         metadata = f'-metadata album="{self._args.title}" -metadata author="{self._args.author}" -metadata album_artist="{self._args.author}"'
-        if self._args.composer:
-            metadata += f' -metadata composer="{self._args.composer}"'
+        if self._args.narrator:
+            metadata += f' -metadata narrator="{self._args.narrator}"'
         return metadata
 
     def _execute_command(self, command: str) -> subprocess.CompletedProcess:
@@ -231,7 +231,7 @@ class AudioBooker:
         # The outfile file must be the last argument in the command
         command += f' "{output_file}"'
         if os.path.isfile(output_file):
-            self._logger.warning(f"The {output_file} chapter file has already been generated")
+            self._logger.warning(f"The {output_file} chapter file is being overwritten")
         self._execute_command(command=command)
 
     def _identify_chapters(self, filename: str, silence_timestamps: tuple[str], is_last_file: bool) -> None:

--- a/main.py
+++ b/main.py
@@ -174,7 +174,7 @@ class AudioBooker:
             if libby_entry["_resourceType"] != "media":
                 self._logger.debug(f"Skipping non-media resource: {libby_entry['_resourceType']}")
                 continue
-            if "odrmediaclips.cachefly.net" not in libby_entry["request"]["url"]:
+            if "audioclips.cdn.overdrive.com" not in libby_entry["request"]["url"]:
                 self._logger.debug(f"Skipping invalid URL: {libby_entry['request']['url']}")
                 continue
             query_timestamp = datetime.fromisoformat(libby_entry["startedDateTime"].replace("Z", "+00:00"))


### PR DESCRIPTION
This pull fixes the problem that causes the failure to run ffmpeg for silence detection.
I have fleshed out the README.md file.
I have added a new command line arg --no_chapters there skips the silence detection and just writes the ~1 hour long Libby part files. The files and tags are labeled "Part n" rather than "Chapter n".
I fixed the writing of the track tags so they are just integers, as required by ID3 standards and expected by iTunes.
I changed the --composer tag to --narrator
I set the default logging level to "WARNING" to make output less verbose.
